### PR TITLE
rebalance an unbalanced tree with `.rebalance()`

### DIFF
--- a/createTree.mjs
+++ b/createTree.mjs
@@ -142,6 +142,10 @@ Deleting node with value = ${value}`);
     return res;
   }
 
+  function rebalance() {
+    return;
+  }
+
   // bfs
   function levelOrder(callback) {
     if (arguments.length === 0 || typeof callback !== "function")
@@ -225,6 +229,7 @@ Deleting node with value = ${value}`);
     preOrder,
     prettyPrint,
     postOrder,
+    rebalance,
   };
 };
 

--- a/createTree.mjs
+++ b/createTree.mjs
@@ -147,7 +147,6 @@ Deleting node with value = ${value}`);
     const pushToSortedArr = (node) => sortedArr.push(node.data);
 
     inOrder(pushToSortedArr);
-    console.log(sortedArr);
     root = buildTree(sortedArr);
     return root;
   }

--- a/createTree.mjs
+++ b/createTree.mjs
@@ -5,14 +5,14 @@ const sortAndDeduplicateArray = (inputArr) =>
 
 const createTree = (inputArr) => {
   const cleanedArr = sortAndDeduplicateArray(inputArr);
-  const root = buildTree();
+  let root = buildTree(cleanedArr);
 
-  function buildTree() {
+  function buildTree(arr) {
     const sortedArrayToBST = (start, end) => {
       if (start > end) return null;
 
       const midIdx = parseInt((start + end) / 2);
-      const node = createNode(cleanedArr[midIdx]);
+      const node = createNode(arr[midIdx]);
 
       node.left = sortedArrayToBST(start, midIdx - 1);
       node.right = sortedArrayToBST(midIdx + 1, end);
@@ -20,7 +20,7 @@ const createTree = (inputArr) => {
       return node;
     };
 
-    return sortedArrayToBST(0, cleanedArr.length - 1);
+    return sortedArrayToBST(0, arr.length - 1);
   }
 
   function insert(value) {
@@ -143,7 +143,13 @@ Deleting node with value = ${value}`);
   }
 
   function rebalance() {
-    return;
+    const sortedArr = [];
+    const pushToSortedArr = (node) => sortedArr.push(node.data);
+
+    inOrder(pushToSortedArr);
+    console.log(sortedArr);
+    root = buildTree(sortedArr);
+    return root;
   }
 
   // bfs

--- a/index.mjs
+++ b/index.mjs
@@ -15,3 +15,8 @@ tree.deleteItem(324);
 
 tree.prettyPrint();
 console.log(tree.isBalanced()); // expected false
+
+// rebalancing
+tree.rebalance();
+tree.prettyPrint();
+console.log(tree.isBalanced()); // expected true

--- a/index.mjs
+++ b/index.mjs
@@ -4,7 +4,7 @@ const testArray = [1, 2, 7, 4, 23, 8, 9, 10, 4, 3, 5, 7, 9, 67, 6345, 324];
 
 const tree = createTree(testArray);
 
-tree.buildTree();
+tree.buildTree(testArray);
 tree.prettyPrint();
 console.log(tree.isBalanced()); // expected true
 
@@ -17,6 +17,6 @@ tree.prettyPrint();
 console.log(tree.isBalanced()); // expected false
 
 // rebalancing
-tree.rebalance();
+// tree.rebalance();
 tree.prettyPrint();
 console.log(tree.isBalanced()); // expected true

--- a/index.mjs
+++ b/index.mjs
@@ -17,6 +17,6 @@ tree.prettyPrint();
 console.log(tree.isBalanced()); // expected false
 
 // rebalancing
-// tree.rebalance();
+tree.rebalance();
 tree.prettyPrint();
 console.log(tree.isBalanced()); // expected true


### PR DESCRIPTION
fixes #15 

# tests
setup (index.mjs) - we create an unbalanced tree in the middle, and then rebalance and check with `.isBalanced()`
```js
import createTree from "./createTree.mjs";

const testArray = [1, 2, 7, 4, 23, 8, 9, 10, 4, 3, 5, 7, 9, 67, 6345, 324];

const tree = createTree(testArray);

tree.buildTree(testArray);
tree.prettyPrint();
console.log(tree.isBalanced()); // expected true

// create an unbalanced tree by removing two levels on the right-most subtree
tree.deleteItem(6345);
tree.deleteItem(67);
tree.deleteItem(324);

tree.prettyPrint();
console.log(tree.isBalanced()); // expected false

// rebalancing
tree.rebalance();
tree.prettyPrint();
console.log(tree.isBalanced()); // expected true
```

output:
![image](https://github.com/user-attachments/assets/0c4f88b6-5d9e-4ae4-92a2-17d1b19ba87b)